### PR TITLE
Misc fixes 2

### DIFF
--- a/meta/Game.lua
+++ b/meta/Game.lua
@@ -488,3 +488,8 @@ end
 ---@param Duration integer
 function Game:MakeShockwave(Position, Amplitude, Speed, Duration)
 end
+
+---Returns `true` if current mode is Hard Mode or Greedier
+---@return boolean
+function Game:IsHardMode()
+end

--- a/meta/ImGui.lua
+++ b/meta/ImGui.lua
@@ -129,7 +129,7 @@ end
 ---Adds an input for keyboard buttons.
 ---@param ParentId string The id of the parent element.
 ---@param ElementId string The id of the keyboard input element.
----@param ButtonLabel Optional. The keyboard input element's label. Default is an empty string.
+---@param ButtonLabel string? Optional. The keyboard input element's label. Default is an empty string.
 ---@param ChangeCallback nil | fun(key: Keyboard, buttonName: string) Optional. Default is nil.
 ---@param DefaultValue number? Optional. Default is 0.
 function ImGui.AddInputKeyboard(ParentId, ElementId, ButtonLabel, ChangeCallback, DefaultValue)

--- a/meta/Vector.lua
+++ b/meta/Vector.lua
@@ -10,6 +10,7 @@ local Vector = {}
 
 ---@param x number
 ---@param y number
+---@return Vector
 function _G.Vector(x, y) end
 
 ---@param AngleDegrees number

--- a/meta/entity/EntityFamiliar.lua
+++ b/meta/entity/EntityFamiliar.lua
@@ -129,3 +129,7 @@ end
 ---@return boolean `true` if it was able to aim.
 function EntityFamiliar:TryAimAtMarkedTarget(aimDirection, direction, unknownVector)
 end
+
+---@return PathFinder
+function EntityFamiliar:GetPathFinder()
+end

--- a/meta/entity/EntityTear.lua
+++ b/meta/entity/EntityTear.lua
@@ -16,12 +16,12 @@
 ---@field StickDiff Vector
 ---@field StickTarget Entity
 ---@field StickTimer integer
----@field TearFlags integer @TearFlags
+---@field TearFlags TearFlags
 ---@field TearIndex integer @const
 ---@field WaitFrames integer
 local EntityTear = {}
 
----@param Flags integer @TearFlags
+---@param Flags TearFlags
 function EntityTear:AddTearFlags(Flags)
 end
 
@@ -29,7 +29,7 @@ end
 function EntityTear:ChangeVariant(NewVariant)
 end
 
----@param Flags integer @TearFlags
+---@param Flags TearFlags
 function EntityTear:ClearTearFlags(Flags)
 end
 
@@ -38,7 +38,7 @@ end
 function EntityTear:GetDeadEyeIntensity()
 end
 
----@param Flags integer @TearFlags
+---@param Flags TearFlags
 ---@return boolean
 function EntityTear:HasTearFlags(Flags)
 end


### PR DESCRIPTION
I made sure VSCode scanned my entire repository for Eevee to dig out any remaining issues. A few fixes here and from the last PR can also be applied to the original extension REPENTOGON-less, so I'd love to see those get in if this gets merged with the original extension.
- Instances of type definition integer @TearFlags > TearFlags
- Fix ButtonLabel Optional. -> ButtonLabel string? Optional.
- Missing Game:IsHardMode
- Missing EntityFamiliar:GetPathFinder
- Forgot to return Vector from new _G.Vector function